### PR TITLE
refactor(test): remove default node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       node-version:
+        required: false
         description: "Node version on which to run the tests"
-        type: number
-        default: 20
+        type: string
 
     secrets:
       turbo_token:
@@ -29,10 +29,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
 
-      # TODO: partition cache based on inputs (os)
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
+          node-version-file: ${{ env.NODE_VERSION == null && '.node-version' || '' }}
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ jobs:
   test:
     uses: driimus/shared-workflows/.github/workflows/test.yml@main
     with:
-      node-version: 20
+      node-version: 22
     # Optional Turborepo credentials to use for Remote Caching
     secrets:
       turbo_token: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
Makes `node-version` an optional input with no default. Instead, the
default node version will be sourced from `.node-version`.
